### PR TITLE
feat: create release-it-to-npm-with-pr-only

### DIFF
--- a/.github/workflows/release-it-with-npm-and-pr-only.yml
+++ b/.github/workflows/release-it-with-npm-and-pr-only.yml
@@ -1,0 +1,81 @@
+name: release-with-npm-and-pr-only
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: build
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Lint
+        run: yarn lint
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build, lint]
+
+    steps:
+      # (1) Create a GitHub App token
+      # Note: the Github App must be installed on the repository and included in the bypass list of the ruleset.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # (2) Use the GitHub App token to init the repository
+          token: ${{ steps.app-token.outputs.token }}
+          # (3) Fetch all history so that release-it can determine the version
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      # (3) Configure Git user
+      - name: Configure Git User
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+
+      - name: Release
+        run: yarn release
+        env:
+          # (4) Make GITHUB_TOKEN available to release-it but use the GitHub App token
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+

--- a/.github/workflows/release-it-with-npm-and-pr-only.yml
+++ b/.github/workflows/release-it-with-npm-and-pr-only.yml
@@ -78,4 +78,6 @@ jobs:
         env:
           # (4) Make GITHUB_TOKEN available to release-it but use the GitHub App token
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # (5) Make NPM_ACCESS_TOKEN available to release-it and npm publish command
+          NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 

--- a/.github/workflows/release-it-with-npm-and-pr-only.yml
+++ b/.github/workflows/release-it-with-npm-and-pr-only.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      # (3) Configure Git user
+      # (4) Configure Git user
       - name: Configure Git User
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
@@ -76,8 +76,8 @@ jobs:
       - name: Release
         run: yarn release
         env:
-          # (4) Make GITHUB_TOKEN available to release-it but use the GitHub App token
+          # (5) Make GITHUB_TOKEN available to release-it but use the GitHub App token
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # (5) Make NPM_ACCESS_TOKEN available to release-it and npm publish command
+          # (6) Make NPM_ACCESS_TOKEN available to release-it and npm publish command
           NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_ACCESS_TOKEN}

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,7 @@
     "release": true
   },
   "npm": {
-    "publish": false
+    "publish": true
   },
   "plugins": {
     "@release-it/conventional-changelog": {
@@ -15,12 +15,10 @@
         "name": "angular",
         "types": {
           "feat": {
-            "section": "Features",
-            "hidden": false
+            "section": "Features"
           },
           "fix": {
-            "section": "Bug Fixes",
-            "hidden": false
+            "section": "Bug Fixes"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "github-actions-playground",
+  "name": "ga-playground",
   "description": "Playground to learn and save all github-actions template I use on my open source projects.",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "packageManager": "yarn@4.6.0",
   "author": "Mirko Quaglia <gladiusservices@protonmail.com> (https://github.com/gladiuscode)",
   "main": "build/index",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "release": "release-it",
+    "release": "release-it --ci --dry-run",
     "build": "tsc",
     "lint": "eslint ./src"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/gladiuscode/github-actions-playground.git"
+    "url": "git+https://github.com/gladiuscode/github-actions-playground.git"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "description": "Playground to learn and save all github-actions template I use on my open source projects.",
   "version": "0.2.0",
   "packageManager": "yarn@4.6.0",
+  "author": "Mirko Quaglia <gladiusservices@protonmail.com> (https://github.com/gladiuscode)",
+  "main": "build/index",
+  "source": "src/index",
+  "files": [
+    "src",
+    "build",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__"
+  ],
   "scripts": {
     "release": "release-it",
     "build": "tsc",
@@ -19,5 +29,20 @@
   },
   "engines": {
     "node": "=18.20.6"
-  }
+  },
+  "keywords": [
+    "github-actions",
+    "github",
+    "actions",
+    "playground",
+    "template"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gladiuscode/github-actions-playground.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This PR implements a new workflow that lets you publish to npm as well as github release.
It requires a new access token to be created as a secret, with the following name: `NPM_ACCESS_TOKEN`.