### PR TITLE
feat: release it with npm pr and inputs

### DIFF
--- a/.github/workflows/release-it-with-npm-and-pr-only-and-inputs.yml
+++ b/.github/workflows/release-it-with-npm-and-pr-only-and-inputs.yml
@@ -1,0 +1,95 @@
+name: release-it-with-npm-and-pr-only-and-inputs
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run release-it in dry-run mode'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: build
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Lint
+        run: yarn lint
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build, lint]
+
+    steps:
+      # (1) Create a GitHub App token
+      # Note: the Github App must be installed on the repository and included in the bypass list of the ruleset.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # (2) Use the GitHub App token to init the repository
+          token: ${{ steps.app-token.outputs.token }}
+          # (3) Fetch all history so that release-it can determine the version
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      # (4) Configure Git user
+      - name: Configure Git User
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+
+      - name: Release Dry Run
+        run: |
+          if [ ${{ inputs.dry-run }} = true ]; then
+            yarn release-it --dry-run
+          else
+            yarn release-it
+          fi
+        env:
+          # (5) Make GITHUB_TOKEN available to release-it but use the GitHub App token
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # (6) Make NPM_ACCESS_TOKEN available to release-it and npm publish command
+          NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "release": "release-it --ci --dry-run",
+    "release": "release-it --ci",
     "build": "tsc",
     "lint": "eslint ./src"
   },


### PR DESCRIPTION
This PR implements a new workflows that accepts a boolean input: dry run.

If the user allows this input, the CI runs the command: yarn release with the --dry-run flag.
This allows us to test the actual release before it gets published.