### PR TITLE
fix: release-it-with-npm-and-pr-only-and-inputs workflow step name

### DIFF
--- a/.github/workflows/release-it-with-npm-and-pr-only-and-inputs.yml
+++ b/.github/workflows/release-it-with-npm-and-pr-only-and-inputs.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           name: build-artifact
 
-      - name: Release Dry Run
+      - name: Release
         run: |
           if [ ${{ inputs.dry-run }} = true ]; then
             yarn release-it --dry-run


### PR DESCRIPTION
This PR fixes the name of the release step 